### PR TITLE
Fix issue when updating Buffersize

### DIFF
--- a/ResizeConsole.ps1
+++ b/ResizeConsole.ps1
@@ -1,4 +1,4 @@
 $width=80
 $height=24
-$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size ($width, $height)
-$host.UI.RawUI.WindowSize = New-Object -TypeName System.Management.Automation.Host.Size -ArgumentList ($width, $height)
+$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size (1000, 9999)
+$host.UI.RawUI.WindowSize = New-Object System.Management.Automation.Host.Size ($width, $height)


### PR DESCRIPTION
```powershell
$Host.UI.RawUI.BufferSize = New-Object Management.Automation.Host.Size ($width, $height)
```
Can fail with the following error message:
```
Exception setting "buffersize": "Cannot set the buffer size because the size specified is too large or too small.
```
By specifying some large static value, we avoid this issue.

I did also change the line for WindowSize to match the style of the line above.

